### PR TITLE
Add version 0.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pytest:
     needs: [lint]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.0.4
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
@@ -27,7 +27,7 @@ jobs:
       run: tox
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.0.4
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -45,7 +45,7 @@ jobs:
   testpypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == true
     needs: [pytest]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.0.4
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -75,7 +75,7 @@ jobs:
   pypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == false
     needs: [pytest]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.0.4
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pytest:
     needs: [lint]
-    runs-on: ubuntu-20.0.4
+    runs-on: ubuntu-22.04.5
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
@@ -27,7 +27,7 @@ jobs:
       run: tox
 
   lint:
-    runs-on: ubuntu-20.0.4
+    runs-on: ubuntu-22.04.5
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -45,7 +45,7 @@ jobs:
   testpypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == true
     needs: [pytest]
-    runs-on: ubuntu-20.0.4
+    runs-on: ubuntu-22.04.5
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -75,7 +75,7 @@ jobs:
   pypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == false
     needs: [pytest]
-    runs-on: ubuntu-20.0.4
+    runs-on: ubuntu-22.04.5
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: tox
 
   lint:
-    runs-on: ubuntu-22.04.5
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -45,7 +45,7 @@ jobs:
   testpypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == true
     needs: [pytest]
-    runs-on: ubuntu-22.04.5
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -75,7 +75,7 @@ jobs:
   pypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == false
     needs: [pytest]
-    runs-on: ubuntu-22.04.5
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pytest:
     needs: [lint]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
@@ -27,7 +27,7 @@ jobs:
       run: tox
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -45,7 +45,7 @@ jobs:
   testpypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == true
     needs: [pytest]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -75,7 +75,7 @@ jobs:
   pypi-package:
     if: github.event_name == 'release' && github.event.release.prerelease == false
     needs: [pytest]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pytest:
     needs: [lint]
-    runs-on: ubuntu-22.04.5
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']

--- a/README.md
+++ b/README.md
@@ -128,15 +128,13 @@ logging.config.dictConfig(LOGGING)
 The essence boils down to adding the RedactingFilter to your logging config, and to the filters section of the associated handlers to which you want to apply the redaction.
 
 
-## Release Notes - v0.0.5:
+## Release Notes - v0.0.6:
 
 ### Improvements and Changes
-- Optimized function that applies the redaction (was setting the logger message value twice).
-- Changed default_mask key initialization to mask
-- Changed patterns key initialization to mask_patterns
+- Allow redaction of any generic mapping type, including `frozendict` and `OrderedDict`.
 
 ### Bug Fixes
-- Handled any exceptions related to deepcopies failing, related to attempt to redact IOStreams, including TypeError
+- Fix bug that was converting non-string data types to strings. (Reported in issue [#7](https://github.com/armurox/loggingredactor/issues/7))
 
 
 ## A Note about the Motivation behind Logging Redactor:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,14 @@ The essence boils down to adding the RedactingFilter to your logging config, and
 ## Release Notes - v0.0.6:
 
 ### Improvements and Changes
-- Allow redaction of any generic mapping type, including `frozendict` and `OrderedDict`.
+- Allow redaction of any generic mapping type, including:
+    1. `dict`
+    2. `collections.OrderedDict`
+    3. `frozendict.frozendict`
+    4. `collections.ChainMap`
+    5. `types.MappingProxyType`
+    6. `collections.UserDict`
+and any other mapping class that inherits from `collections.Mapping`
 
 ### Bug Fixes
 - Fix bug that was converting non-string data types to strings. (Reported in issue [#7](https://github.com/armurox/loggingredactor/issues/7))

--- a/loggingredactor/redacting_filter.py
+++ b/loggingredactor/redacting_filter.py
@@ -1,6 +1,7 @@
 import re
 import logging
 import copy
+from collections.abc import Mapping
 
 
 class RedactingFilter(logging.Filter):
@@ -32,22 +33,23 @@ class RedactingFilter(logging.Filter):
         except Exception:
             return content
         if content_copy:
-            if isinstance(content_copy, dict):
-                for k, v in content_copy.items():
-                    content_copy[k] = self._mask if k in self._mask_keys else self.redact(v)
+            if isinstance(content_copy, Mapping):  # Covers all dict-like objects
+                content_copy = type(content_copy)({
+                    k: self._mask if k in self._mask_keys else self.redact(v)
+                    for k, v in content_copy.items()
+                })
 
             elif isinstance(content_copy, list):
                 content_copy = [self.redact(value) for value in content_copy]
 
-            elif isinstance(content, tuple):
+            elif isinstance(content_copy, tuple):
                 content_copy = tuple(self.redact(value) for value in content_copy)
 
             # Support for keys in extra field
             elif key and key in self._mask_keys:
                 content_copy = self._mask
 
-            else:
-                content_copy = isinstance(content_copy, str) and content_copy or str(content_copy)
+            elif isinstance(content_copy, str):
                 for pattern in self._mask_patterns:
                     content_copy = re.sub(pattern, self._mask, content_copy)
 

--- a/loggingredactor/redacting_filter.py
+++ b/loggingredactor/redacting_filter.py
@@ -34,10 +34,10 @@ class RedactingFilter(logging.Filter):
             return content
         if content_copy:
             if isinstance(content_copy, Mapping):  # Covers all dict-like objects
-                content_copy = type(content_copy)({
-                    k: self._mask if k in self._mask_keys else self.redact(v)
+                content_copy = type(content_copy)([
+                    (k, self._mask if k in self._mask_keys else self.redact(v))
                     for k, v in content_copy.items()
-                })
+                ])
 
             elif isinstance(content_copy, list):
                 content_copy = [self.redact(value) for value in content_copy]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ branch = os.getenv('GITHUB_REF', 'master').split('/')[-1]  # Default to 'master'
 url = f"https://github.com/armurox/loggingredactor/tree/{branch}"
 
 # Get version from environment variable
-version = os.getenv('RELEASE_VERSION', '0.0.6')  # Default to '0.0.5' if RELEASE_VERSION is not set
+version = os.getenv('RELEASE_VERSION', '0.0.6')  # Default to '0.0.6' if RELEASE_VERSION is not set
 # Get development status
 split_version = version.split('-')
 if len(split_version) == 2:

--- a/tests/test_redacting_filter.py
+++ b/tests/test_redacting_filter.py
@@ -183,7 +183,7 @@ def test_extra_do_redact_key(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "****"
     assert extra_data == {'thing987': '123'}
-    assert type(extra_data) == dict
+    assert isinstance(extra_data, dict)
 
 
 def test_extra_do_redact_key_frozen_dict(caplog, logger_setup):
@@ -192,7 +192,7 @@ def test_extra_do_redact_key_frozen_dict(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "****"
     assert extra_data == {'thing987': '123'}
-    assert type(extra_data) == frozendict
+    assert isinstance(extra_data, frozendict)
 
 
 def test_extra_do_redact_key_ordered_dict(caplog, logger_setup):
@@ -201,7 +201,7 @@ def test_extra_do_redact_key_ordered_dict(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "****"
     assert extra_data == {'thing987': '123'}
-    assert type(extra_data) == OrderedDict
+    assert isinstance(extra_data, OrderedDict)
 
 
 def test_extra_do_not_redact_key(caplog, logger_setup):
@@ -210,7 +210,7 @@ def test_extra_do_not_redact_key(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "foobar"
     assert extra_data == {'thing987': 'foobar'}
-    assert type(extra_data) == dict
+    assert isinstance(extra_data, dict)
 
 
 def test_extra_do_not_redact_key_frozen_dict(caplog, logger_setup):
@@ -219,7 +219,7 @@ def test_extra_do_not_redact_key_frozen_dict(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "foobar"
     assert extra_data == {'thing987': 'foobar'}
-    assert type(extra_data) == frozendict
+    assert isinstance(extra_data, frozendict)
 
 
 def test_extra_do_not_redact_key_ordered_dict(caplog, logger_setup):
@@ -228,7 +228,7 @@ def test_extra_do_not_redact_key_ordered_dict(caplog, logger_setup):
     logger.warning("foo", extra=extra_data)
     assert caplog.records[0].thing987 == "foobar"
     assert extra_data == {'thing987': 'foobar'}
-    assert type(extra_data) == OrderedDict
+    assert isinstance(extra_data, OrderedDict)
 
 
 def test_extra_nested_dict_with_list(caplog, logger_setup):
@@ -246,7 +246,7 @@ def test_extra_nested_dict_with_list(caplog, logger_setup):
             'thing': ['one', '456'],
         },
     }
-    assert type(extra_data) == dict
+    assert isinstance(extra_data, dict)
 
 
 def test_extra_nested_frozen_dict_with_list(caplog, logger_setup):
@@ -264,7 +264,7 @@ def test_extra_nested_frozen_dict_with_list(caplog, logger_setup):
             'thing': ['one', '456'],
         },
     }
-    assert type(extra_data) == frozendict
+    assert isinstance(extra_data, frozendict)
 
 
 def test_extra_nested_ordered_dict_with_list(caplog, logger_setup):
@@ -282,7 +282,7 @@ def test_extra_nested_ordered_dict_with_list(caplog, logger_setup):
             'thing': ['one', '456'],
         },
     }
-    assert type(extra_data) == OrderedDict
+    assert isinstance(extra_data, OrderedDict)
 
 
 def test_extra_nested_dict_with_tuple(caplog, logger_setup):
@@ -300,7 +300,7 @@ def test_extra_nested_dict_with_tuple(caplog, logger_setup):
             'thing': ('one', '456'),
         },
     }
-    assert type(extra_data) == dict
+    assert isinstance(extra_data, dict)
 
 
 def test_extra_nested_frozen_dict_with_tuple(caplog, logger_setup):
@@ -318,7 +318,7 @@ def test_extra_nested_frozen_dict_with_tuple(caplog, logger_setup):
             'thing': ('one', '456'),
         },
     }
-    assert type(extra_data) == frozendict
+    assert isinstance(extra_data, frozendict)
 
 
 def test_extra_nested_ordered_dict_with_tuple(caplog, logger_setup):
@@ -336,7 +336,7 @@ def test_extra_nested_ordered_dict_with_tuple(caplog, logger_setup):
             'thing': ('one', '456'),
         },
     }
-    assert type(extra_data) == OrderedDict
+    assert isinstance(extra_data, OrderedDict)
 
 
 def test_match_group(caplog, logger_setup):

--- a/tests/test_redacting_filter.py
+++ b/tests/test_redacting_filter.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 
 MAPPING_TYPES = [dict, OrderedDict, UserDict, ChainMap, frozendict, MappingProxyType]
 
+
 @pytest.fixture
 def logger_setup(request):
     def get_logger(filters=''):

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,10 @@ deps = ruff
 commands = ruff check .
 
 [testenv]
-deps = pytest-cov
+deps =
+    pytest-cov
+    frozendict
+    .
 commands = python -m pytest --cov=./loggingredactor
 
 [testenv:flake8]


### PR DESCRIPTION
Resolved Issues:
- #7 

Added Features:
- Redaction now applied to generic mapping types, including:
    1. `dict`
    2. `collections.OrderedDict`
    3. `frozendict.frozendict`
    4. `collections.ChainMap`
    5. `types.MappingProxyType`
    6. `collections.UserDict`
and any other mapping class that inherits from `collections.Mapping`
